### PR TITLE
fixed a bug in config

### DIFF
--- a/simplecv/core/config.py
+++ b/simplecv/core/config.py
@@ -4,11 +4,14 @@ class AttrDict(dict):
         self.update(kwargs)
 
     def __setitem__(self, key: str, value):
-        if isinstance(value, dict):
-            value = AttrDict(**value)
         super(AttrDict, self).__setitem__(key, value)
         super(AttrDict, self).__setattr__(key, value)
 
-    def update(self, config):
+    def update(self, config: dict):
         for k, v in config.items():
-            self[k] = v
+            if k not in self:
+                self[k] = AttrDict()
+            if isinstance(v, dict):
+                self[k].update(v)
+            else:
+                self[k] = v


### PR DESCRIPTION
In the original version, the imported configuration will directly replace the default value rather than update the value, which causes python "dict" object is lack of default value ignored in the imported configuration.